### PR TITLE
fix: issue with incorrect conditions

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -151,7 +151,12 @@
       - The template is defined (will be undefined for app proxies like /apps|a|community|tools/*)
       - The current template is not the login page, unless multipass login is enabled
     {% endcomment %}
-    {%- assign should_redirect = template != blank and template.name != 'login' or settings.multipass_login -%}
+    {%- liquid
+       assign should_redirect = false
+       if settings.multipass_login or template != blank and template.name != 'login'
+         assign should_redirect = true
+       endif
+    -%}
 
     {%- if settings.storefront_hostname != blank and should_redirect -%}
     <script>
@@ -181,12 +186,12 @@
           var customRedirectsStr = "{{ settings.custom_redirects | newline_to_br | strip_newlines | replace: ' ', '' }}";
           if (customRedirectsStr) {
             var customRedirects = customRedirectsStr.split('<br/>');
-  
+
             for (var cri = 0; cri < customRedirects.length; cri += 1) {
               var redirect = customRedirects[cri].split('>');
               var fromPath = redirect[0];
               var toPath = redirect[1];
-  
+
               if (fromPath && toPath && redirectUrl.startsWith('https://' + storefrontHostname + fromPath)) {
                 redirectUrl = redirectUrl.replace(storefrontHostname + fromPath, storefrontHostname + toPath);
                 break;
@@ -196,7 +201,7 @@
 
           redirectUrl = new URL(redirectUrl);
 
-          {% comment %} 
+          {% comment %}
             Handle discount code logic (e.g. xxx.myshopify.com/discount/freeshipping?redirect=/products)
             - Add discount code to as param to the edirect URL if the `discount_code` cookie exists
             - Cookie is deleted after to prevent it from being automatically added to other routes


### PR DESCRIPTION
Hi there! I found a problem here. We cannot use expressions in a variable declaration. For example, this was discussed [here](https://github.com/Shopify/liquid/issues/1102). So the variable `should_redirect` will always be truly except when `template` is not defined. Because `should_redirect` is equal to `template` in fact and will return a string.

Also when multiple conditions are used, the order works from [right to left](https://shopify.github.io/liquid/basics/operators#order-of-operations). I hope this makes sense. Thanks.